### PR TITLE
feat: add print/PDF export for character sheets and campaign party

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,7 +1,7 @@
-\restrict bdxk7HhlJ2tBMIAhfsHW7NEJV2Tds4pzM26GncBVgMc3cGjqhK0wZpDjytIrYWa
+\restrict 80st7V0ac1xEJzZE70scgHOnzUka92uyFA9kxQw3TOth1KmJbzGxF1Cubd5Hhq6
 
--- Dumped from database version 16.10
--- Dumped by pg_dump version 18.3
+-- Dumped from database version 16.14
+-- Dumped by pg_dump version 18.4 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1559,7 +1559,7 @@ ALTER TABLE ONLY public.items
 -- PostgreSQL database dump complete
 --
 
-\unrestrict bdxk7HhlJ2tBMIAhfsHW7NEJV2Tds4pzM26GncBVgMc3cGjqhK0wZpDjytIrYWa
+\unrestrict 80st7V0ac1xEJzZE70scgHOnzUka92uyFA9kxQw3TOth1KmJbzGxF1Cubd5Hhq6
 
 
 --

--- a/src/components/Campaign.tsx
+++ b/src/components/Campaign.tsx
@@ -198,19 +198,32 @@ export const Campaign = ({ campaign }: CampaignProps) => {
           <div class="col-12">
             <div class="d-flex justify-content-between align-items-center mb-3">
               <h3>Characters & Members</h3>
-              {campaign.canInviteMembers && (
-                <button
-                  type="button"
-                  class="btn btn-primary btn-sm"
-                  data-bs-toggle="modal"
-                  data-bs-target="#detailModal"
-                  hx-get={`/campaigns/${campaign.id}/invite`}
-                  hx-target="#detailModalContent"
-                  hx-swap="innerHTML"
-                >
-                  <i class="bi bi-person-plus"></i> Invite Member
-                </button>
-              )}
+              <div class="d-flex gap-2">
+                {isDM && (
+                  <a
+                    href={`/campaigns/${campaign.id}/print`}
+                    target="_blank"
+                    class="btn btn-outline-secondary btn-sm"
+                    title="Print all character sheets"
+                  >
+                    <i class="bi bi-printer me-1"></i>
+                    Print All
+                  </a>
+                )}
+                {campaign.canInviteMembers && (
+                  <button
+                    type="button"
+                    class="btn btn-primary btn-sm"
+                    data-bs-toggle="modal"
+                    data-bs-target="#detailModal"
+                    hx-get={`/campaigns/${campaign.id}/invite`}
+                    hx-target="#detailModalContent"
+                    hx-swap="innerHTML"
+                  >
+                    <i class="bi bi-person-plus"></i> Invite Member
+                  </button>
+                )}
+              </div>
             </div>
 
             {partyMembers.length === 0 ? (

--- a/src/components/CampaignPrint.tsx
+++ b/src/components/CampaignPrint.tsx
@@ -1,0 +1,87 @@
+import type { ComputedCampaign } from "@src/services/campaigns/compute"
+import type { ComputedCharacter } from "@src/services/computeCharacter"
+import { CharacterSheetBody, PRINT_STYLES } from "./CharacterPrint"
+
+interface CampaignPrintProps {
+  campaign: ComputedCampaign
+  characters: ComputedCharacter[]
+}
+
+const CoverPage = ({
+  campaign,
+  characters,
+}: {
+  campaign: ComputedCampaign
+  characters: ComputedCharacter[]
+}) => (
+  <div style="padding-bottom: 1in;">
+    <div style="border-bottom: 2pt solid #1a1a1a; padding-bottom: 8pt; margin-bottom: 16pt;">
+      <div style="font-size: 6pt; text-transform: uppercase; letter-spacing: 0.1em; color: #666; margin-bottom: 4pt;">
+        Campaign
+      </div>
+      <div style="font-size: 22pt; font-weight: bold; margin: 0 0 4pt 0;">{campaign.name}</div>
+      {campaign.description && (
+        <div style="font-size: 9pt; color: #555; margin-top: 4pt;">{campaign.description}</div>
+      )}
+    </div>
+
+    <div style="font-size: 7pt; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; color: #444; border-bottom: 0.5pt solid #bbb; padding-bottom: 3pt; margin-bottom: 8pt;">
+      Party
+    </div>
+
+    {characters.map((char) => {
+      const classLabel = char.classes
+        .map((c) => `${c.class.charAt(0).toUpperCase() + c.class.slice(1)} ${c.level}`)
+        .join(" / ")
+      return (
+        <div
+          style="display:flex; justify-content:space-between; align-items:baseline; padding: 4pt 0; border-bottom: 0.5pt solid #eee; font-size: 9pt;"
+          key={char.id}
+        >
+          <span style="font-weight: bold;">{char.name}</span>
+          <span style="color: #555; font-size: 8pt; text-transform: capitalize;">{classLabel}</span>
+          <span style="color: #777; font-size: 7.5pt; text-transform: capitalize;">
+            {char.species ?? ""}
+          </span>
+          <span style="color: #777; font-size: 7.5pt; text-transform: capitalize;">
+            {char.background ?? ""}
+          </span>
+        </div>
+      )
+    })}
+
+    <div style="margin-top: 20pt; font-size: 7pt; color: #aaa;">
+      Printed {new Date().toLocaleDateString()}
+    </div>
+  </div>
+)
+
+export const CampaignPrint = ({ campaign, characters }: CampaignPrintProps) => (
+  <html lang="en">
+    <head>
+      <title>{campaign.name} — Party Sheets</title>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: fully controlled CSS string, not user input */}
+      <style dangerouslySetInnerHTML={{ __html: PRINT_STYLES }} />
+    </head>
+    <body>
+      <div class="action-bar">
+        <button type="button" onclick="window.print()">
+          Print / Save as PDF
+        </button>
+        <a href={`/campaigns/${campaign.id}`}>← Back to campaign</a>
+      </div>
+      <div class="print-sheet">
+        <CoverPage campaign={campaign} characters={characters} />
+        {characters.map((char) => (
+          <div key={char.id} style="break-before: page; page-break-before: always;">
+            <CharacterSheetBody character={char} />
+          </div>
+        ))}
+      </div>
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: fully controlled script string, not user input */}
+      <script dangerouslySetInnerHTML={{ __html: "window.print()" }} />
+    </body>
+  </html>
+)

--- a/src/components/CharacterInfo.tsx
+++ b/src/components/CharacterInfo.tsx
@@ -360,6 +360,21 @@ export const CharacterInfo = ({ character, swapOob, isReadOnly = false }: Charac
               )}
             </div>
 
+            {/* Print button — available to everyone including DMs */}
+            <div class="row g-2 h-auto mt-2">
+              <div class="col-12 d-flex justify-content-center">
+                <a
+                  href={`/characters/${character.id}/print`}
+                  target="_blank"
+                  class="btn btn-sm btn-outline-secondary"
+                  title="Print / Save as PDF"
+                >
+                  <i class="bi bi-printer me-1"></i>
+                  Print
+                </a>
+              </div>
+            </div>
+
             {/* Rest Buttons */}
             {!isReadOnly && (
               <div class="row g-2 h-auto mt-2">

--- a/src/components/CharacterPrint.tsx
+++ b/src/components/CharacterPrint.tsx
@@ -1,0 +1,722 @@
+import { Abilities, type AbilityType, type ProficiencyLevel, Skills } from "@src/lib/dnd"
+import { spells as allSpells } from "@src/lib/dnd/spells"
+import type { CharacterClass, ComputedCharacter, SkillScore } from "@src/services/computeCharacter"
+import type { Child } from "hono/jsx"
+
+// ---- Helpers ----
+
+const fmt = (n: number) => (n >= 0 ? `+${n}` : `${n}`)
+
+const classString = (classes: CharacterClass[]) =>
+  classes.map((c) => `${c.class.charAt(0).toUpperCase() + c.class.slice(1)} ${c.level}`).join(" / ")
+
+function groupHitDice(dice: number[]): string {
+  const counts = new Map<number, number>()
+  for (const d of dice) counts.set(d, (counts.get(d) ?? 0) + 1)
+  return Array.from(counts.entries())
+    .map(([die, count]) => `${count}d${die}`)
+    .join(", ")
+}
+
+function groupSlots(slots: number[]): Map<number, number> {
+  const map = new Map<number, number>()
+  for (const s of slots) map.set(s, (map.get(s) ?? 0) + 1)
+  return map
+}
+
+// ---- Inline CSS ----
+
+export const PRINT_STYLES = `
+@page { size: letter portrait; margin: 0.5in; }
+* { box-sizing: border-box; }
+body {
+  font-family: Georgia, 'Times New Roman', serif;
+  font-size: 9pt;
+  color: #1a1a1a;
+  background: white;
+  margin: 0;
+  padding: 0;
+}
+
+/* Screen preview */
+@media screen {
+  body { background: #aaa; }
+  .print-sheet {
+    background: white;
+    max-width: 8.5in;
+    margin: 0 auto;
+    padding: 0.5in;
+    box-shadow: 0 2px 14px rgba(0,0,0,0.45);
+    min-height: 11in;
+  }
+}
+
+/* Action bar — hidden on print */
+.action-bar {
+  background: #f0f0f0;
+  border-bottom: 1px solid #ccc;
+  padding: 8px 16px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 13px;
+}
+.action-bar button {
+  background: #222;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 14px;
+  cursor: pointer;
+  font-size: 13px;
+}
+.action-bar a { color: #555; text-decoration: none; }
+@media print { .action-bar { display: none !important; } }
+
+/* Header */
+.sheet-header {
+  border-bottom: 2pt solid #1a1a1a;
+  padding-bottom: 5pt;
+  margin-bottom: 7pt;
+}
+.char-name {
+  font-size: 18pt;
+  font-weight: bold;
+  margin: 0 0 4pt 0;
+  letter-spacing: -0.3pt;
+}
+.char-meta { display: flex; flex-wrap: wrap; gap: 0 14pt; }
+.char-meta-item { display: flex; flex-direction: column; }
+.char-meta-label {
+  font-size: 5.5pt;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: #666;
+}
+.char-meta-value {
+  font-size: 8pt;
+  font-weight: bold;
+  text-transform: capitalize;
+}
+
+/* Two-column body */
+.sheet-body {
+  display: grid;
+  grid-template-columns: 40% 60%;
+  gap: 8pt;
+}
+
+/* Sections */
+.section {
+  border: 0.75pt solid #888;
+  border-radius: 3pt;
+  margin-bottom: 5pt;
+  padding: 3pt 5pt;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+.section-title {
+  font-size: 5.5pt;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #444;
+  border-bottom: 0.5pt solid #bbb;
+  padding-bottom: 2pt;
+  margin: 0 0 3pt 0;
+}
+
+/* Abilities */
+.abilities-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4pt;
+}
+.ability-box {
+  border: 0.75pt solid #555;
+  border-radius: 3pt;
+  padding: 3pt;
+  text-align: center;
+  break-inside: avoid;
+  page-break-inside: avoid;
+}
+.ability-name {
+  font-size: 6pt;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  border-bottom: 0.5pt solid #ccc;
+  padding-bottom: 1.5pt;
+  margin-bottom: 2pt;
+  color: #222;
+}
+.ability-modifier {
+  font-size: 16pt;
+  font-weight: bold;
+  line-height: 1;
+  margin: 1pt 0;
+}
+.ability-score {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20pt;
+  height: 20pt;
+  border: 1.25pt solid #444;
+  border-radius: 50%;
+  font-size: 7.5pt;
+  font-weight: bold;
+  margin: 1.5pt auto;
+}
+.ability-save {
+  font-size: 6pt;
+  color: #555;
+}
+.ability-save b { font-size: 6.5pt; }
+
+/* Proficiency dot */
+.prof-dot {
+  display: inline-block;
+  width: 7pt;
+  height: 7pt;
+  border-radius: 50%;
+  border: 0.75pt solid #555;
+  flex-shrink: 0;
+  vertical-align: middle;
+}
+.prof-dot.half {
+  background: linear-gradient(to right, #444 50%, transparent 50%);
+}
+.prof-dot.proficient {
+  background: #222;
+  border-color: #111;
+}
+.prof-dot.expert {
+  background: #222;
+  border-color: #111;
+  border-radius: 0;
+  clip-path: polygon(50% 0%, 63% 34%, 98% 35%, 70% 57%, 80% 91%, 50% 70%, 20% 91%, 30% 57%, 2% 35%, 37% 34%);
+}
+
+/* Saving throws */
+.save-row {
+  display: flex;
+  align-items: center;
+  gap: 4pt;
+  padding: 1.5pt 0;
+  border-bottom: 0.5pt solid #eee;
+  font-size: 7.5pt;
+}
+.save-name { flex: 1; text-transform: capitalize; }
+.save-mod { font-weight: bold; min-width: 16pt; text-align: right; }
+
+/* Skills */
+.skill-row {
+  display: flex;
+  align-items: center;
+  gap: 3pt;
+  padding: 1.5pt 0;
+  border-bottom: 0.5pt solid #eee;
+  font-size: 7pt;
+}
+.skill-ability {
+  font-size: 5.5pt;
+  color: #888;
+  width: 18pt;
+  text-align: center;
+}
+.skill-name { flex: 1; text-transform: capitalize; }
+.skill-mod { font-weight: bold; min-width: 16pt; text-align: right; }
+
+/* Combat row */
+.combat-row { display: flex; gap: 5pt; margin-bottom: 5pt; }
+.combat-box {
+  flex: 1;
+  border: 0.75pt solid #666;
+  border-radius: 3pt;
+  text-align: center;
+  padding: 4pt 2pt;
+  break-inside: avoid;
+}
+.combat-value { font-size: 14pt; font-weight: bold; line-height: 1.1; }
+.combat-label { font-size: 5.5pt; text-transform: uppercase; letter-spacing: 0.06em; color: #555; }
+
+/* HP */
+.hp-row { display: flex; gap: 5pt; margin-bottom: 5pt; }
+.hp-box {
+  flex: 1;
+  border: 0.75pt solid #666;
+  border-radius: 3pt;
+  text-align: center;
+  padding: 4pt 2pt;
+}
+.hp-value { font-size: 17pt; font-weight: bold; line-height: 1; }
+.hp-label { font-size: 5.5pt; text-transform: uppercase; color: #555; letter-spacing: 0.05em; }
+
+/* Items */
+.item-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5pt 0;
+  border-bottom: 0.5pt solid #eee;
+  font-size: 7.5pt;
+  gap: 4pt;
+}
+.item-name { font-weight: 600; flex: 1; }
+.item-detail { color: #555; font-size: 6.5pt; text-align: right; }
+
+/* Coins */
+.coin-row { display: flex; gap: 8pt; padding-top: 3pt; }
+.coin-item { text-align: center; }
+.coin-value { font-weight: bold; font-size: 8.5pt; }
+.coin-label { font-size: 5.5pt; text-transform: uppercase; color: #666; }
+
+/* Page 2 */
+.page-2 { break-before: page; page-break-before: always; }
+.traits-grid { columns: 2; column-gap: 12pt; }
+.trait-item { break-inside: avoid; page-break-inside: avoid; margin-bottom: 6pt; }
+.trait-source { font-size: 5.5pt; text-transform: uppercase; color: #888; letter-spacing: 0.08em; }
+.trait-name { font-weight: bold; font-size: 8pt; text-transform: capitalize; }
+.trait-note { font-size: 6.5pt; color: #555; font-style: italic; }
+.trait-desc { font-size: 7pt; color: #333; margin-top: 1pt; white-space: pre-wrap; word-break: break-word; }
+
+/* Spells */
+.spell-class-row {
+  display: flex;
+  gap: 8pt;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  margin-bottom: 5pt;
+}
+.spell-stat {
+  text-align: center;
+  border: 0.75pt solid #666;
+  border-radius: 3pt;
+  padding: 2pt 6pt;
+}
+.spell-stat-value { font-size: 11pt; font-weight: bold; line-height: 1.1; }
+.spell-stat-label { font-size: 5.5pt; text-transform: uppercase; color: #555; }
+.spell-class-name {
+  font-size: 9pt;
+  font-weight: bold;
+  text-transform: capitalize;
+  flex: 1;
+}
+.spell-slots-row { display: flex; flex-wrap: wrap; gap: 3pt; margin-bottom: 5pt; }
+.spell-slot {
+  width: 18pt;
+  height: 18pt;
+  border: 0.75pt solid #444;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 6pt;
+  font-weight: bold;
+}
+.spell-slot.used { background: #333; color: white; border-color: #111; }
+.spell-list { columns: 2; column-gap: 10pt; margin-bottom: 8pt; }
+.spell-item {
+  display: flex;
+  justify-content: space-between;
+  font-size: 7.5pt;
+  padding: 1pt 0;
+  border-bottom: 0.5pt solid #eee;
+  break-inside: avoid;
+}
+.spell-level { font-size: 6pt; color: #777; }
+`
+
+// ---- Sub-components ----
+
+const PrintProfDot = ({ level }: { level: ProficiencyLevel }) => (
+  <span class={`prof-dot ${level}`} />
+)
+
+const PrintAbilityBox = ({
+  name,
+  score,
+  modifier,
+  savingThrow,
+  proficient,
+}: {
+  name: AbilityType
+  score: number
+  modifier: number
+  savingThrow: number
+  proficient: boolean
+}) => (
+  <div class="ability-box">
+    <div class="ability-name">{name.slice(0, 3).toUpperCase()}</div>
+    <div class="ability-modifier">{fmt(modifier)}</div>
+    <div class="ability-score">{score}</div>
+    <div class="ability-save">
+      save: <b>{fmt(savingThrow)}</b>
+      {proficient && " ●"}
+    </div>
+  </div>
+)
+
+const PrintSkillRow = ({ skill, skillScore }: { skill: string; skillScore: SkillScore }) => (
+  <div class="skill-row">
+    <PrintProfDot level={skillScore.proficiency} />
+    <span class="skill-ability">{skillScore.ability.slice(0, 3).toUpperCase()}</span>
+    <span class="skill-name">{skill}</span>
+    <span class="skill-mod">{fmt(skillScore.modifier)}</span>
+  </div>
+)
+
+const PrintSection = ({ title, children }: { title: string; children?: Child | Child[] }) => (
+  <div class="section">
+    <div class="section-title">{title}</div>
+    {children}
+  </div>
+)
+
+// ---- Page 1 columns ----
+
+const LeftColumn = ({ character }: { character: ComputedCharacter }) => (
+  <div>
+    <PrintSection title="Ability Scores">
+      <div class="abilities-grid">
+        {Abilities.map((ability) => {
+          const ab = character.abilityScores[ability]
+          return (
+            <PrintAbilityBox
+              name={ability}
+              score={ab.score}
+              modifier={ab.modifier}
+              savingThrow={ab.savingThrow}
+              proficient={ab.proficient}
+            />
+          )
+        })}
+      </div>
+    </PrintSection>
+
+    <PrintSection title="Saving Throws">
+      {Abilities.map((ability) => {
+        const ab = character.abilityScores[ability]
+        return (
+          <div class="save-row">
+            <PrintProfDot level={ab.proficient ? "proficient" : "none"} />
+            <span class="save-name">{ability}</span>
+            <span class="save-mod">{fmt(ab.savingThrow)}</span>
+          </div>
+        )
+      })}
+    </PrintSection>
+
+    <PrintSection title="Skills">
+      {Skills.map((skill) => (
+        <PrintSkillRow skill={skill} skillScore={character.skills[skill]} />
+      ))}
+    </PrintSection>
+  </div>
+)
+
+const RightColumn = ({ character }: { character: ComputedCharacter }) => {
+  const weapons = character.equippedItems.filter((i) => i.wielded && i.damage.length > 0)
+  const equipment = character.equippedItems.filter((i) => !weapons.includes(i))
+  const coins = character.coins ?? { pp: 0, gp: 0, ep: 0, sp: 0, cp: 0 }
+  const totalHitDice = groupHitDice(character.hitDice)
+  const availHitDice = groupHitDice(character.availableHitDice)
+
+  return (
+    <div>
+      {/* Combat stats */}
+      <div class="combat-row">
+        <div class="combat-box">
+          <div class="combat-value">{character.armorClass}</div>
+          <div class="combat-label">Armor Class</div>
+        </div>
+        <div class="combat-box">
+          <div class="combat-value">{fmt(character.initiative)}</div>
+          <div class="combat-label">Initiative</div>
+        </div>
+        <div class="combat-box">
+          <div class="combat-value">{character.speed}</div>
+          <div class="combat-label">Speed (ft)</div>
+        </div>
+      </div>
+
+      {/* HP */}
+      <div class="hp-row">
+        <div class="hp-box">
+          <div class="hp-value">{character.currentHP}</div>
+          <div class="hp-label">Current HP</div>
+        </div>
+        <div class="hp-box">
+          <div class="hp-value">{character.maxHitPoints}</div>
+          <div class="hp-label">Max HP</div>
+        </div>
+      </div>
+
+      {/* Hit Dice + Passive Perception */}
+      <div style="display:flex;gap:5pt;margin-bottom:5pt;">
+        <div class="combat-box" style="flex:2">
+          <div class="combat-value" style="font-size:10pt;">
+            {availHitDice || "—"} / {totalHitDice || "—"}
+          </div>
+          <div class="combat-label">Hit Dice (available / total)</div>
+        </div>
+        <div class="combat-box" style="flex:1">
+          <div class="combat-value">{character.passivePerception}</div>
+          <div class="combat-label">Passive Perception</div>
+        </div>
+      </div>
+
+      {/* Weapons */}
+      {weapons.length > 0 && (
+        <PrintSection title="Weapons">
+          {weapons.map((w) => (
+            <div class="item-row">
+              <span class="item-name">{w.name}</span>
+              <span class="item-detail">{w.humanReadableDamage.join(", ")}</span>
+            </div>
+          ))}
+        </PrintSection>
+      )}
+
+      {/* Equipment */}
+      {equipment.length > 0 && (
+        <PrintSection title="Equipment">
+          {equipment.map((item) => (
+            <div class="item-row">
+              <span class="item-name">{item.name}</span>
+              <span class="item-detail">
+                {item.worn ? "worn" : item.wielded ? "wielded" : ""}
+                {item.currentCharges > 0 ? ` (${item.currentCharges} ${item.chargeLabel})` : ""}
+              </span>
+            </div>
+          ))}
+        </PrintSection>
+      )}
+
+      {/* Coins */}
+      <PrintSection title="Coins">
+        <div class="coin-row">
+          {coins.pp > 0 && (
+            <div class="coin-item">
+              <div class="coin-value">{coins.pp}</div>
+              <div class="coin-label">PP</div>
+            </div>
+          )}
+          <div class="coin-item">
+            <div class="coin-value">{coins.gp}</div>
+            <div class="coin-label">GP</div>
+          </div>
+          {coins.ep > 0 && (
+            <div class="coin-item">
+              <div class="coin-value">{coins.ep}</div>
+              <div class="coin-label">EP</div>
+            </div>
+          )}
+          <div class="coin-item">
+            <div class="coin-value">{coins.sp}</div>
+            <div class="coin-label">SP</div>
+          </div>
+          <div class="coin-item">
+            <div class="coin-value">{coins.cp}</div>
+            <div class="coin-label">CP</div>
+          </div>
+        </div>
+      </PrintSection>
+    </div>
+  )
+}
+
+// ---- Page 2: Traits ----
+
+const TraitsPage = ({ character }: { character: ComputedCharacter }) => {
+  const hasSpells = character.spells.length > 0
+  const totalSlots = groupSlots(character.spellSlots)
+  const availSlots = groupSlots(character.availableSpellSlots)
+  const pactSlots = character.pactMagicSlots ? groupSlots(character.pactMagicSlots) : null
+
+  return (
+    <div class="page-2">
+      <PrintSection title="Traits & Features">
+        <div class="traits-grid">
+          {character.traits.map((t) => (
+            <div class="trait-item">
+              <div class="trait-source">
+                {t.source}
+                {t.source_detail ? ` · ${t.source_detail}` : ""}
+                {t.level ? ` (level ${t.level})` : ""}
+              </div>
+              <div class="trait-name">{t.name}</div>
+              {t.note && <div class="trait-note">{t.note}</div>}
+              <div class="trait-desc">{t.description}</div>
+            </div>
+          ))}
+        </div>
+      </PrintSection>
+
+      {hasSpells && (
+        <PrintSection title="Spells">
+          {/* Per-class spellcasting stats */}
+          {character.spells.map((spellInfo) => {
+            const cantrips = spellInfo.cantripSlots
+              .filter((s) => s.spell_id)
+              .map((s) => allSpells.find((sp) => sp.id === s.spell_id))
+              .filter(Boolean)
+            const prepared = spellInfo.preparedSpells
+              .filter((s) => s.spell_id)
+              .map((s) => allSpells.find((sp) => sp.id === s.spell_id))
+              .filter(Boolean)
+
+            return (
+              <div style="margin-bottom:8pt;">
+                <div class="spell-class-row">
+                  <span class="spell-class-name">{spellInfo.class} Spells</span>
+                  <div class="spell-stat">
+                    <div class="spell-stat-value">{fmt(spellInfo.spellAttackBonus)}</div>
+                    <div class="spell-stat-label">Spell Attack</div>
+                  </div>
+                  <div class="spell-stat">
+                    <div class="spell-stat-value">{spellInfo.spellSaveDC}</div>
+                    <div class="spell-stat-label">Save DC</div>
+                  </div>
+                </div>
+
+                {/* Spell slots for this section (shown once under first class) */}
+                {character.spells.indexOf(spellInfo) === 0 && totalSlots.size > 0 && (
+                  <div style="margin-bottom:5pt;">
+                    <div class="section-title" style="margin-bottom:3pt;">
+                      Spell Slots
+                    </div>
+                    <div class="spell-slots-row">
+                      {Array.from({ length: 9 }, (_, i) => i + 1).map((level) => {
+                        const total = totalSlots.get(level) ?? 0
+                        const avail = availSlots.get(level) ?? 0
+                        if (total === 0) return null
+                        return Array.from({ length: total }, (_, i) => (
+                          <div class={`spell-slot${i >= avail ? " used" : ""}`}>L{level}</div>
+                        ))
+                      })}
+                    </div>
+                  </div>
+                )}
+
+                {/* Pact magic slots */}
+                {pactSlots && pactSlots.size > 0 && character.spells.indexOf(spellInfo) === 0 && (
+                  <div style="margin-bottom:5pt;">
+                    <div class="section-title" style="margin-bottom:3pt;">
+                      Pact Magic Slots
+                    </div>
+                    <div class="spell-slots-row">
+                      {Array.from(pactSlots.entries()).map(([level, count]) =>
+                        Array.from({ length: count }, () => <div class="spell-slot">L{level}</div>)
+                      )}
+                    </div>
+                  </div>
+                )}
+
+                {/* Cantrips + prepared spells */}
+                {(cantrips.length > 0 || prepared.length > 0) && (
+                  <div class="spell-list">
+                    {cantrips.map((spell) => (
+                      <div class="spell-item">
+                        <span>{spell!.name}</span>
+                        <span class="spell-level">Cantrip</span>
+                      </div>
+                    ))}
+                    {prepared.map((spell) => (
+                      <div class="spell-item">
+                        <span>{spell!.name}</span>
+                        <span class="spell-level">Lv {spell!.level}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )
+          })}
+        </PrintSection>
+      )}
+    </div>
+  )
+}
+
+// ---- Full sheet body (exported for CampaignPrint reuse) ----
+
+export const CharacterSheetBody = ({ character }: { character: ComputedCharacter }) => {
+  const meta = character.lineage ? `${character.species} (${character.lineage})` : character.species
+
+  return (
+    <>
+      <div class="sheet-header">
+        <div class="char-name">{character.name}</div>
+        <div class="char-meta">
+          <div class="char-meta-item">
+            <span class="char-meta-label">Class &amp; Level</span>
+            <span class="char-meta-value">{classString(character.classes)}</span>
+          </div>
+          {character.species && (
+            <div class="char-meta-item">
+              <span class="char-meta-label">Species</span>
+              <span class="char-meta-value">{meta}</span>
+            </div>
+          )}
+          {character.background && (
+            <div class="char-meta-item">
+              <span class="char-meta-label">Background</span>
+              <span class="char-meta-value">{character.background}</span>
+            </div>
+          )}
+          {character.alignment && (
+            <div class="char-meta-item">
+              <span class="char-meta-label">Alignment</span>
+              <span class="char-meta-value">{character.alignment}</span>
+            </div>
+          )}
+          <div class="char-meta-item">
+            <span class="char-meta-label">Proficiency Bonus</span>
+            <span class="char-meta-value">{fmt(character.proficiencyBonus)}</span>
+          </div>
+          <div class="char-meta-item">
+            <span class="char-meta-label">Size</span>
+            <span class="char-meta-value">{character.size}</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="sheet-body">
+        <LeftColumn character={character} />
+        <RightColumn character={character} />
+      </div>
+
+      <TraitsPage character={character} />
+    </>
+  )
+}
+
+// ---- Standalone page ----
+
+export const CharacterPrint = ({ character }: { character: ComputedCharacter }) => (
+  <html lang="en">
+    <head>
+      <title>{character.name} — Character Sheet</title>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: fully controlled CSS string, not user input */}
+      <style dangerouslySetInnerHTML={{ __html: PRINT_STYLES }} />
+    </head>
+    <body>
+      <div class="action-bar">
+        <button type="button" onclick="window.print()">
+          Print / Save as PDF
+        </button>
+        <a href={`/characters/${character.id}`}>← Back to character sheet</a>
+      </div>
+      <div class="print-sheet">
+        <CharacterSheetBody character={character} />
+      </div>
+      {/* biome-ignore lint/security/noDangerouslySetInnerHtml: fully controlled script string, not user input */}
+      <script dangerouslySetInnerHTML={{ __html: "window.print()" }} />
+    </body>
+  </html>
+)

--- a/src/db.ts
+++ b/src/db.ts
@@ -2,11 +2,16 @@ import { SQL, type TransactionSQL } from "bun"
 import type { Context } from "hono"
 import { config } from "./config"
 
-// Construct PostgreSQL connection URL
-const connectionUrl = `postgres://${config.postgresUser}:${config.postgresPassword}@${config.postgresHost}:${config.postgresPort}/${config.postgresDb}`
-
 // not exported; we should only use getDb to access the database
-const db = new SQL(connectionUrl)
+// Note: Bun.sql ignores the database name when parsing a connection URL (Bun bug),
+// so we use the options object form to ensure the correct database is used.
+const db = new SQL({
+  hostname: config.postgresHost,
+  port: Number(config.postgresPort),
+  username: config.postgresUser,
+  password: config.postgresPassword,
+  database: config.postgresDb,
+})
 
 /**
  * Get the database instance from the context or use the global instance

--- a/src/routes/campaigns.test.ts
+++ b/src/routes/campaigns.test.ts
@@ -2551,3 +2551,103 @@ describe("Campaign page buttons", () => {
     })
   })
 })
+
+describe("GET /campaigns/:id/print", () => {
+  const testCtx = useTestApp()
+
+  describe("when user is not authenticated", () => {
+    test("redirects to login", async () => {
+      const response = await makeRequest(testCtx.app, "/campaigns/some-id/print")
+
+      expect(response.status).toBe(302)
+      expect(response.headers.get("Location")).toContain("/login")
+    })
+  })
+
+  describe("when user is authenticated", () => {
+    let dmUser: User
+    let campaign: Campaign
+
+    beforeEach(async () => {
+      dmUser = await userFactory.create({}, testCtx.db)
+      campaign = await campaignFactory.create({ created_by: dmUser.id }, testCtx.db)
+    })
+
+    test("returns 200 for DM", async () => {
+      const response = await makeRequest(testCtx.app, `/campaigns/${campaign.id}/print`, {
+        user: dmUser,
+      })
+
+      expect(response.status).toBe(200)
+    })
+
+    test("renders campaign name in print page", async () => {
+      const response = await makeRequest(testCtx.app, `/campaigns/${campaign.id}/print`, {
+        user: dmUser,
+      })
+
+      const document = await parseHtml(response)
+      const body = document.body.textContent || ""
+
+      expect(body).toContain(campaign.name)
+    })
+
+    describe("with a party character", () => {
+      let playerUser: User
+      let character: Character
+
+      beforeEach(async () => {
+        playerUser = await userFactory.create({}, testCtx.db)
+        character = await characterFactory.create({ user_id: playerUser.id }, testCtx.db)
+        await campaignCharacterFactory.create(
+          { campaign_id: campaign.id, character_id: character.id, added_by: dmUser.id },
+          testCtx.db
+        )
+      })
+
+      test("returns 200 with the party character added", async () => {
+        const response = await makeRequest(testCtx.app, `/campaigns/${campaign.id}/print`, {
+          user: dmUser,
+        })
+
+        expect(response.status).toBe(200)
+      })
+    })
+
+    describe("when user is a player, not DM", () => {
+      let playerUser: User
+
+      beforeEach(async () => {
+        playerUser = await userFactory.create({}, testCtx.db)
+        await campaignMemberFactory.create(
+          {
+            campaign_id: campaign.id,
+            user_id: playerUser.id,
+            invited_by: dmUser.id,
+            role: "player",
+          },
+          testCtx.db
+        )
+      })
+
+      test("redirects non-DM members", async () => {
+        const response = await makeRequest(testCtx.app, `/campaigns/${campaign.id}/print`, {
+          user: playerUser,
+        })
+
+        expect(response.status).toBe(302)
+      })
+    })
+
+    describe("when user is not a campaign member", () => {
+      test("redirects non-members", async () => {
+        const outsider = await userFactory.create({}, testCtx.db)
+        const response = await makeRequest(testCtx.app, `/campaigns/${campaign.id}/print`, {
+          user: outsider,
+        })
+
+        expect(response.status).toBe(302)
+      })
+    })
+  })
+})

--- a/src/routes/campaigns.tsx
+++ b/src/routes/campaigns.tsx
@@ -2,6 +2,7 @@ import { AddCharacterToCampaign } from "@src/components/AddCharacterToCampaign"
 import { Campaign } from "@src/components/Campaign"
 import { CampaignInviteForm } from "@src/components/CampaignInviteForm"
 import { CampaignNew } from "@src/components/CampaignNew"
+import { CampaignPrint } from "@src/components/CampaignPrint"
 import { Campaigns } from "@src/components/Campaigns"
 import { ChangeRoleForm } from "@src/components/ChangeRoleForm"
 import { getDb } from "@src/db"
@@ -21,6 +22,7 @@ import { removeCharacterFromCampaign } from "@src/services/campaigns/removeChara
 import { respondToInvite } from "@src/services/campaigns/respond"
 import { hideCharacter, revealCharacter } from "@src/services/campaigns/revealCharacter"
 import { unarchiveCampaign } from "@src/services/campaigns/unarchive"
+import { computeCharacter } from "@src/services/computeCharacter"
 import { listCharacters } from "@src/services/listCharacters"
 import { Hono } from "hono"
 
@@ -72,6 +74,25 @@ campaignsRoutes.get("/campaigns/:id", async (c) => {
   return c.render(<Campaign campaign={authResult.campaign} />, {
     title: authResult.campaign.name,
   })
+})
+
+campaignsRoutes.get("/campaigns/:id/print", async (c) => {
+  const id = c.req.param("id") as string
+
+  const authResult = await authorizeCampaign(c, id)
+  if (!authResult.allowed) return handleCampaignUnallowed(c, authResult.reason)
+  if (authResult.role !== "dm") return handleCampaignUnallowed(c, "not_member")
+
+  const db = getDb(c)
+  const characters = (
+    await Promise.all(
+      authResult.campaign.characters
+        .filter((cc) => !cc.isNPC)
+        .map((cc) => computeCharacter(db, cc.character_id))
+    )
+  ).filter((c): c is NonNullable<typeof c> => c !== null)
+
+  return c.html(<CampaignPrint campaign={authResult.campaign} characters={characters} />)
 })
 
 campaignsRoutes.post("/campaigns/:id/archive", async (c) => {

--- a/src/routes/character.test.ts
+++ b/src/routes/character.test.ts
@@ -4,6 +4,7 @@ import type { Upload } from "@src/db/uploads"
 import { UploadStatus } from "@src/db/uploads"
 import type { User } from "@src/db/users"
 import { useTestApp } from "@src/test/app"
+import { campaignCharacterFactory, campaignFactory } from "@src/test/factories/campaign"
 import { characterFactory } from "@src/test/factories/character"
 import { uploadFactory } from "@src/test/factories/upload"
 import { userFactory } from "@src/test/factories/user"
@@ -745,6 +746,74 @@ describe("Character archiving - name reuse", () => {
       expect(body).toContain("You haven't created any characters yet")
       // Should show checkbox since archived characters exist
       expect(body).toContain("Show archived characters")
+    })
+  })
+})
+
+describe("GET /characters/:id/print", () => {
+  const testCtx = useTestApp()
+
+  describe("when user is not authenticated", () => {
+    test("redirects to login", async () => {
+      const response = await makeRequest(testCtx.app, "/characters/some-id/print")
+
+      expect(response.status).toBe(302)
+      expect(response.headers.get("Location")).toContain("/login")
+    })
+  })
+
+  describe("when user is authenticated", () => {
+    let user: User
+    let character: Character
+
+    beforeEach(async () => {
+      user = await userFactory.create({}, testCtx.db)
+      character = await characterFactory.create({ user_id: user.id }, testCtx.db)
+    })
+
+    test("returns 200 for character owner", async () => {
+      const response = await makeRequest(testCtx.app, `/characters/${character.id}/print`, { user })
+
+      expect(response.status).toBe(200)
+    })
+
+    test("renders character name in print page", async () => {
+      const response = await makeRequest(testCtx.app, `/characters/${character.id}/print`, { user })
+
+      const document = await parseHtml(response)
+      const body = document.body.textContent || ""
+
+      expect(body).toContain(character.name)
+    })
+
+    test("returns 302 for a character the user does not own and is not DM of", async () => {
+      const otherUser = await userFactory.create({}, testCtx.db)
+      const response = await makeRequest(testCtx.app, `/characters/${character.id}/print`, {
+        user: otherUser,
+      })
+
+      expect(response.status).toBe(302)
+    })
+
+    describe("when user is DM of a campaign containing the character", () => {
+      let dmUser: User
+
+      beforeEach(async () => {
+        dmUser = await userFactory.create({}, testCtx.db)
+        const campaign = await campaignFactory.create({ created_by: dmUser.id }, testCtx.db)
+        await campaignCharacterFactory.create(
+          { campaign_id: campaign.id, character_id: character.id, added_by: dmUser.id },
+          testCtx.db
+        )
+      })
+
+      test("returns 200 for the DM", async () => {
+        const response = await makeRequest(testCtx.app, `/characters/${character.id}/print`, {
+          user: dmUser,
+        })
+
+        expect(response.status).toBe(200)
+      })
     })
   })
 })

--- a/src/routes/character.tsx
+++ b/src/routes/character.tsx
@@ -11,6 +11,7 @@ import { Character } from "@src/components/Character"
 import { CharacterImport } from "@src/components/CharacterImport"
 import { CharacterInfo } from "@src/components/CharacterInfo"
 import { CharacterNew } from "@src/components/CharacterNew"
+import { CharacterPrint } from "@src/components/CharacterPrint"
 import { Characters } from "@src/components/Characters"
 import { ChargeManagementForm } from "@src/components/ChargeManagementForm"
 import { ClassEditForm } from "@src/components/ClassEditForm"
@@ -208,6 +209,14 @@ characterRoutes.get("/characters/:id", async (c) => {
       title: "Character Sheet",
     }
   )
+})
+
+characterRoutes.get("/characters/:id/print", async (c) => {
+  const id = c.req.param("id") as string
+  const authResult = await authorizeCharacterView(c, id)
+  if (!authResult.allowed) return handleUnallowed(c, authResult.reason)
+  const char = authResult.character
+  return c.html(<CharacterPrint character={char} />)
 })
 
 characterRoutes.post("/characters/:id/archive", async (c) => {


### PR DESCRIPTION
## Summary

- Adds `GET /characters/:id/print` — a standalone, print-optimized character sheet accessible to both the character owner and any DM of a campaign containing the character
- Adds `GET /campaigns/:id/print` — a DM-only route that prints all party characters back-to-back with a cover page listing the party
- Adds **Print** button to the character sheet and **Print All** button (DM-only) to the campaign view, both opening in a new tab

## How it works

Uses the browser's built-in print dialog (Ctrl+P → Save as PDF) — **zero new runtime dependencies**. The print route returns a standalone `<html>` document via `c.html()`, bypassing the app's jsxRenderer layout. It auto-triggers `window.print()` on load.

The character sheet uses a two-column grid layout:
- **Left (~40%):** ability scores (3×2 grid with modifier + score circle), saving throws, skills with proficiency dots
- **Right (~60%):** AC / Initiative / Speed, current & max HP, hit dice, attacks & weapons, equipment, coins
- **Page 2** (forced page break): traits & features in a 2-column flow, spells section (rendered only if the character has spells)

The visual style extends the app's existing aesthetic — clean bordered boxes, minimal typography — translated to print-optimized CSS with `@page { size: letter portrait; margin: 0.5in; }`. A screen preview mode wraps the sheet in a gray background so it looks like a real page at 8.5in width.

## Bug fix: Bun.sql database URL parsing

Fixes a bug in `src/db.ts` where `Bun.sql` 1.3.1 silently ignores the database name in a PostgreSQL connection URL, connecting to the default `postgres` database instead of `csheet_dev`. Switched from the URL string form to the options object form (`new SQL({ hostname, port, username, password, database })`).

## Test plan

- [ ] Navigate to a character sheet and click **Print** — new tab opens with the print-optimized sheet, `window.print()` fires automatically
- [ ] Verify two-column layout on page 1, traits/spells on page 2
- [ ] Open browser print dialog (Cmd+P) and confirm the action bar is hidden in print preview
- [ ] As a DM, navigate to a campaign and click **Print All** — all party character sheets render back-to-back with a cover page
- [ ] Confirm non-DM members cannot access `/campaigns/:id/print` (redirected)
- [ ] `mise run test src/routes/character.test.ts` — 44 tests pass
- [ ] `mise run test src/routes/campaigns.test.ts` — 115 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)